### PR TITLE
Urlの取得処理をコメントアウト

### DIFF
--- a/src/classes/util/WelUtil.php
+++ b/src/classes/util/WelUtil.php
@@ -419,9 +419,11 @@ class WelUtil
             $urlBase .= ':' . $urlInfo['port'];
         }
         $urlBase .= '/';
+        /*
         if (Pocket::getInstance()->dirWelCMS()) {
             $urlBase .= Pocket::getInstance()->dirWelCMS();
         }
+        */
         return $urlBase . StringUtil::leftRemove($path, '/');
     }
 


### PR DESCRIPTION
CMSを下層ディレクトリに置いた場合の処理は後で修正が必要